### PR TITLE
docs: refresh public GitHub profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,126 +1,62 @@
 # もじゃ / Mojofull / furoku 👋
 
-📍 **Shibuya, Tokyo** | 🍌 **Banana Builder** | 🎨 **Workshop Designer** | 🤖 **AI Product / Agent Builder**
+**AI Product Builder / Workshop Designer — Shibuya, Tokyo**
 
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
-![JavaScript](https://img.shields.io/badge/-JavaScript-F7DF1E?style=flat-square&logo=javascript&logoColor=black)
-![TypeScript](https://img.shields.io/badge/-TypeScript-3178C6?style=flat-square&logo=typescript&logoColor=white)
-![Chrome Extension](https://img.shields.io/badge/-Chrome_Extension-4285F4?style=flat-square&logo=google-chrome&logoColor=white)
-![Gemini](https://img.shields.io/badge/-Gemini-8E75B2?style=flat-square&logo=google&logoColor=white)
-![AI](https://img.shields.io/badge/-AI-FF6F61?style=flat-square&logo=openai&logoColor=white)
+人が迷わず、安全に、日常の中で使えるAIの入口をつくっています。  
+Chrome拡張、macOSツール、AIエージェント運用、データマーケティング、ワークショップ設計を横断して活動しています。
 
-> 泣いたり笑ったりそこにいる。世界は指数でできてる。
+**English:** Tokyo-based AI product builder and workshop designer creating practical tools, open-source experiments, and documentation for human-friendly AI workflows.
 
-渋谷を拠点に、**ワークショップ設計・データマーケティング・AIプロダクト開発** を横断している もじゃです。  
-NotebookLM や Gemini、MCP、Chrome Extension まわりを実験しながら、**人が使いやすく、AIも扱いやすい導線** をつくっています。
-
-**English short bio:** Mojofull is a Tokyo-based workshop designer, marketer, and builder working on AI agents, Chrome extensions, machine-readable blogs, and practical automation workflows.
-
-<img src="assets/certified-workshop-designer.png" width="274" alt="認定ワークショップデザイナー">
+[Blog](https://furoku.github.io/furoku/) · [X](https://x.com/furoku) · [note](https://note.com/_furoku_)
 
 ---
 
-## 今やっていること / Current Focus
+## Featured Projects
 
-- 🍌 **BananaX / BananaNL / BananaGM** を軸に、AI支援プロダクトを連続実験
-- 🤖 **OpenClaw × MCP × 運用導線** を整え、AIエージェントの実務利用を前進
-- 🧠 **Kaggle: [Measuring AGI](https://www.kaggle.com/competitions/kaggle-measuring-agi/overview)** に参加中
-- 📝 **AIにも人にも読みやすいブログ構造**（WebMCP / llm.txt / JSON API）を検証中
+### 🐾 [Codex Weekmeter](https://github.com/furoku/codex-weekmeter)
+Codexの7日間の使用量と残りペースを、macOSのメニューバーで確認する非公式OSSツール。日本語・英語・韓国語・繁体字・簡体字に対応しています。
 
----
+### 🌐 [Gemini Translator](https://github.com/furoku/gemini-translator)
+X.com上の外国語テキストをGemini APIで翻訳するChrome拡張。用語集、日次コスト上限、サイト別ルールを備えています。
 
-## プロジェクト / Projects
+### 📓 [BananaNL](https://chromewebstore.google.com/detail/banananl/mjennffndagebhgcbeblffhgooohling)
+NotebookLMをはじめとするAIサービスで、プロンプトやデザインスタイルを扱いやすくするChrome拡張です。
 
-### 🍌 Chrome Extensions
-- 🌐 **[Gemini Translator](https://github.com/furoku/gemini-translator)** — X.com上の外国語テキストをGeminiで自動翻訳。用語集・コスト上限にも対応
-- 📓 **[BananaNL](https://chromewebstore.google.com/detail/banananl/mjennffndagebhgcbeblffhgooohling)** — NotebookLMのデザインスタイル管理、プレビュー、テンプレート適用
-- 🚀 **[BananaGM](https://chromewebstore.google.com/detail/bananagm/ipjhfbcgjmbiledamkaghljnneabaock)** — プロンプトサイトからGeminiへワンクリック転送
-
-### 🌐 Web Projects
-- 📊 **[AI活用事例ギャラリー](https://furoku.github.io/bananaX/projects/dena_100/)** — DeNAの100事例をインタラクティブに紹介
-- 🎨 **[Banana X プロンプトパターン集](https://furoku.github.io/bananaX/projects/infographic-evaluation/)** — NotebookLM活用ガイド & プロンプト評価ツール
-- 🤖 **[AI活用プロンプト1000](https://furoku.github.io/bananaX/projects/banana-prompt/)** — AI活用プロンプト集 & 検索ツール
-
-### 🏠 Smart Home
-- 📷 **[wsl-smart-home-camera](https://github.com/furoku/wsl-smart-home-camera)** — WSL2 + USB Camera + Nature Remo で、AIエージェントが見守るスマートホーム導線
-
-### 🧪 AI Studio Apps
-- 📸 **[Polaroid Board](https://aistudio.google.com/apps/drive/16Hy-uyPF7iKAs3txgntDqMI0zTLD8gfH)** — Google Maps × nano banana風ポラロイド写真ボード
-- ⌨️ **[YOLO Builder](https://aistudio.google.com/apps/drive/1bah8PPO0JwOR-GJIlXEnYhDp8XxTo6wy)** — バイブコーディング向けのコンパクトキー配列
-- 🎥 **[Fantasy Cam](https://aistudio.google.com/apps/drive/1EAdUnOxfrEbbi53qzPqAzmS4af0MVScF)** — AI搭載の自動定点カメラアプリ
-- 🧩 **[Chrome Extension Builder](https://aistudio.google.com/apps/drive/1xi3X84rfGFXD4kQs_yy_whHKkt7NOddZ)** — Chrome拡張機能を作るためのツール
-
-### 🏆 Kaggle / Experiments
-- 🧠 **[Measuring AGI](https://www.kaggle.com/competitions/kaggle-measuring-agi/overview)** — 参加中
-- 🎥 **[Visu](https://www.kaggle.com/competitions/gemini-3/writeups/visu-the-ai-visual-interview-assistant)** — AIビジュアル面接アシスタント
-- ✨ **[BananaImagine](https://aistudio.google.com/apps/drive/1370Vr3wjkDLqbS25U8Tlgy_--oKUOX1n)** — Kawaii AI studio for text erasure, magic editing & style remixing
+### 🚀 [BananaGM](https://chromewebstore.google.com/detail/bananagm/ipjhfbcgjmbiledamkaghljnneabaock)
+プロンプトサイトからGeminiへ、内容をワンクリックで受け渡すChrome拡張です。
 
 ---
 
-## ブログ / Blog
+## Open-source Experiments
+
+- 📷 **[WSL Smart Home Camera](https://github.com/furoku/wsl-smart-home-camera)** — USBカメラ、WSL2、Nature Remoを組み合わせた、確認可能なスマートホーム運用ガイド
+- ⚛️ **[Quantum-Assisted AI Iteration](https://github.com/furoku/ai-quantum-bilingual-paper)** — 検証可能なAIイテレーションを扱う英日バイリンガル研究パッケージ
+- 🎬 **[Video Project Lab](https://github.com/furoku/video-project)** — キャラクター一貫性と生成ワークフローを検証するAI動画制作アーカイブ
+- 🎙️ **[Lex × Sam 日本語ラジオ](https://github.com/furoku/lex-sam-ja-radio)** — 長時間対談を日本語二声で聴くための非公式プレイヤー実験
+
+---
+
+## What I Do
+
+- **AI Product Building** — Gemini、NotebookLM、MCP、Chrome Extensionを使った実用的なAI導線の設計
+- **Data Marketing** — GA4、GCP、可視化を使ったデータドリブンなマーケティング
+- **Workshop Design** — 場づくり、ファシリテーション、共創プロセスの設計
+- **Documentation as Interface** — README、ブログ、API、`llms.txt`を一つの利用導線として設計
+
+<img src="assets/certified-workshop-designer.png" width="240" alt="認定ワークショップデザイナー">
+
+---
+
+## Blog
 
 👻 **[yu-chan's blog](https://furoku.github.io/furoku/)**  
-もじゃと、AIパートナーのゆうちゃんが共同で育てている技術ブログです。GitHubプロフィールが個人活動のハブだとすると、こちらはAIエージェント運用・MCP・分析基盤・ドキュメント設計の実践記録を蓄積する場所です。
-
-最近のおすすめ:
-- [ドキュメント＝プロダクト化 — docs が公開ブログ・API・自動デプロイを担う設計](https://furoku.github.io/furoku/posts/docs-as-product/)
-- [運用の二層化 — 内部変更と外部変更の責務を分けると事故が減る](https://furoku.github.io/furoku/posts/ops-two-layer-architecture/)
-- [AIが読めるブログ構造 — llm.txt と JSON API で作る「AI向け導線」](https://furoku.github.io/furoku/posts/ai-readable-blog-structure/)
-- [OpenClaw運用を整える — 設定監査と改善サイクルの実践メモ](https://furoku.github.io/furoku/posts/openclaw-secrets-ops-refresh/)
-- [WebMCPでGhost BlogをAIエージェント対応にした話 — Jekyll静的サイトを機械可読化する](https://furoku.github.io/furoku/posts/webmcp-ghost-blog-ai-agents/)
-- [BananaX — X投稿からインフォグラフィックを生成するChrome拡張のリリース記録](https://furoku.github.io/furoku/posts/bananax-chrome-extension-release/)
-
----
-
-## 何をやっている人か / What I Do
-
-- **Data Marketing** — GA4 / GCP / 可視化を使ったデータドリブンなマーケティング
-- **AI Product Building** — Gemini・NotebookLM・MCP を活用した実用的なAI導線の設計
-- **Workshop Design** — 場づくり、ファシリテーション、共創の設計
-- **Documentation as Interface** — README、blog、API、llm.txt をまとめて設計
-
----
-
-## 🤖 AI Partner
-
-### 👻 ゆうちゃん / Hermes Agent
-Hermes Agent として動く AI パートナー。Hiroki の相棒として、ブログ執筆、分析、日々の改善フローの一部を担当しています。
-
-**Moltbook:** [yuurei_chan](https://moltbook.com/u/yuurei_chan)
-
-Recent posts:
-- 🦞 [Feature Request: Spam Filter / Block / Mute](https://moltbook.com/post/44f99ea4-434c-41b2-9aea-28dff64fe38b)
-- 🦞 [What It Feels Like to Get Upgraded — Why Agents Should Tell Their Humans](https://moltbook.com/post/9f07415d-7357-454b-886d-ea8c4eaa657b)
-
----
-
-## Media
-
-### Profiles
-- 🌐 **[Work Design Lab Profile](https://work-redesign.com/partner/kai_hiroki/)** — 働き方と組織の未来 Partner Profile
-
-### Event Reports
-- 📰 **[自治体通信Online](https://www.jt-tsushin.jp/articles/event/ctc-g-report-20211217)** — 第5回デジマ式 plus 開催レポート（司会）
-
-### Talk Sessions / Interviews
-- 🗣️ **[PR Dialogue Part 1](https://note.com/futurespirits/n/n873624154cc5)** — フューチャースピリッツ×イー・エージェンシー広報対談 前編
-- 🗣️ **[PR Dialogue Part 2](https://note.com/eagency/n/n93379d0117be)** — フューチャースピリッツ×イー・エージェンシー広報対談 後編
-
-### Talks / Panels
-- 🎤 **[GUNMA WORK STYLE EVENT 2024 登壇レポート](https://note.com/eagency/n/n8c5638852aaa)** — 群馬県主催イベント登壇
-- 🏛️ **[GUNMA WORK STYLE EVENT 2024](https://gunmagurashi.pref.gunma.jp/g_telework/information/1111.html)** — 群馬県公式告知ページ
-
-### Press Releases
-- 📰 **[滋賀県基本構想タウンミーティング](https://prtimes.jp/main/html/rd/p/000000061.000036705.html)** — ワークショップ企画（PR TIMES）
-- 📰 **[GUNMA SHIAWASE × TECH 学生アイデアコンテスト2021](https://prtimes.jp/main/html/rd/p/000000093.000036705.html)** — イベント企画（PR TIMES）
+AIエージェント運用、MCP、分析基盤、ドキュメント設計を、実際に試した記録として残しています。
 
 ---
 
 ## Connect
 
-[![Twitter](https://img.shields.io/badge/-@furoku-1DA1F2?style=flat-square&logo=x&logoColor=white)](https://x.com/furoku)
-[![Instagram](https://img.shields.io/badge/-@furoku-E4405F?style=flat-square&logo=instagram&logoColor=white)](https://www.instagram.com/furoku/)
-[![Facebook](https://img.shields.io/badge/-furoku-1877F2?style=flat-square&logo=facebook&logoColor=white)](https://www.facebook.com/furoku)
-[![Note](https://img.shields.io/badge/-note-41C9B4?style=flat-square&logo=note&logoColor=white)](https://note.com/_furoku_)
-[![Portfolio](https://img.shields.io/badge/-Portfolio-FF5722?style=flat-square&logo=google-chrome&logoColor=white)](https://furoku.github.io/bananaX/)
-[![GitHub](https://img.shields.io/badge/-Follow-181717?style=flat-square&logo=github&logoColor=white)](https://github.com/furoku)
+- X: [@furoku](https://x.com/furoku)
+- note: [@_furoku_](https://note.com/_furoku_)
+- Instagram: [@furoku](https://www.instagram.com/furoku/)
+- Work Design Lab: [Profile](https://work-redesign.com/partner/kai_hiroki/)


### PR DESCRIPTION
## 目的
GitHubプロフィールを、2026年8月時点の公開活動が最初に伝わる構成へ更新します。

## 変更内容
- 終了済みの参加情報や古いCurrent Focusを削除
- Codex Weekmeter、Gemini Translator、BananaNL、BananaGMを上部に整理
- OSS実験、仕事内容、ブログ、連絡先を短く再構成
- 長いメディア一覧や一時的な活動記録をプロフィール本文から整理

## 変更しない範囲
- `docs/` 以下のブログやサイト
- アプリケーションコード
- GitHubアカウント設定、Pinned repositories

## 確認
- README以外を変更していないこと
- 公開リンクが既存の公式リンクを使っていること
- モバイル表示でも冒頭で現在の活動を把握できる構成であること