### PR TITLE
docs: remove private Codex Weekmeter from public profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,6 @@ Chrome拡張、macOSツール、AIエージェント運用、データマーケ�
 
 ## Featured Projects
 
-### 🐾 [Codex Weekmeter](https://github.com/furoku/codex-weekmeter)
-Codexの7日間の使用量と残りペースを、macOSのメニューバーで確認する非公式OSSツール。日本語・英語・韓国語・繁体字・簡体字に対応しています。
-
 ### 🌐 [Gemini Translator](https://github.com/furoku/gemini-translator)
 X.com上の外国語テキストをGemini APIで翻訳するChrome拡張。用語集、日次コスト上限、サイト別ルールを備えています。
 


### PR DESCRIPTION
## 変更内容
- 非公開化した `furoku/codex-weekmeter` を、公開プロフィールREADMEの Featured Projects から削除

## 変更しない範囲
- 他のFeatured Projects、Open-source Experiments、ブログ、外部リンクは変更していません

## 確認
- 公開プロフィールから、閲覧できない非公開リポジトリへの導線だけがなくなることを確認します